### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,12 @@ find_package(geometry_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
 add_executable(odom_to_tf src/odom_to_tf.cpp)
-ament_target_dependencies(odom_to_tf 
-  rclcpp
-  tf2_ros
-  nav_msgs
-  geometry_msgs
-  tf2_geometry_msgs
+target_link_libraries(odom_to_tf
+  rclcpp::rclcpp
+  tf2_ros::tf2_ros
+  ${nav_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${tf2_geometry_msgs_TARGETS}
 )
 
 install(TARGETS odom_to_tf


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__odom_to_tf_ros2__ubuntu_noble_amd64__binary/